### PR TITLE
Don't crash when creating the first blog post

### DIFF
--- a/SiteConfig.groovy
+++ b/SiteConfig.groovy
@@ -199,7 +199,12 @@ commands = [
     def date = new Date()
     def fileDate = date.format("yyyy-MM-dd")
     def filename = fileDate + "-" + postTitle.encodeAsSlug() + ".markdown"
-    def file = new File(content_dir + "/blog/" + filename)
+    def blogDir = new File(content_dir + "/blog/")
+    if (!blogDir.exists()) {
+        blogDir.mkdirs()
+    }
+    def file = new File(blogDir, filename)
+
     file.exists() || file.write("""---
 layout: post
 title: "${postTitle}"


### PR DESCRIPTION
Right now, if you delete all the existing example posts via IntelliJ (as I suspect many people will), it also deletes the blog dir inside content. Subsequently, running grainw create-post will crash because the blog dir is gone. This fixes that to create it if it's missing.
