### PR TITLE
Customizable blog post URLs using ResourceMapper

### DIFF
--- a/theme/src/com/sysgears/octopress/mapping/ResourceMapper.groovy
+++ b/theme/src/com/sysgears/octopress/mapping/ResourceMapper.groovy
@@ -44,7 +44,7 @@ class ResourceMapper {
             resource
         }.sort { -it.date.time }
         
-        customizeModels << addSiteMenu << customizeAsides << refinedResources
+        checkForDuplicateUrls << customizeModels << addSiteMenu << customizeAsides << refinedResources
     }
 
     /**
@@ -193,6 +193,24 @@ class ResourceMapper {
                 page
             }
         }
+    }
+
+    /**
+     * Ensures all resources have unique URLs.
+     *
+     * @param resources to validate.
+     * @throw RuntimeException when a duplicate URL is found.
+     * @return the resources unchanged.
+     */
+    private def checkForDuplicateUrls = { List resources ->
+        def urls = [:]
+
+        resources.each { resource -> 
+            if(urls.containsKey(resource.url)) throw new RuntimeException("Encountered duplicate resource URL: $resource.url") 
+            else urls[resource.url] = null
+        }
+
+        resources
     }
 
     /**

--- a/theme/src/com/sysgears/octopress/mapping/ResourceMapper.groovy
+++ b/theme/src/com/sysgears/octopress/mapping/ResourceMapper.groovy
@@ -20,6 +20,12 @@ class ResourceMapper {
      */
     private TweetsFetcher tweetsFetcher
 
+    /**
+     * The blog post URL base path. Change the value to customize.
+     * Defaults to /blog/
+     */
+    public String postUrlBasePath = '/blog/'
+
     public ResourceMapper(Site site) {
         this.site = site
         tweetsFetcher = new TweetsFetcher(site)
@@ -39,6 +45,21 @@ class ResourceMapper {
         }.sort { -it.date.time }
         
         customizeModels << addSiteMenu << customizeAsides << refinedResources
+    }
+
+    /**
+     * Creates URL for a post page relative to postUrlBasePath.
+     * Replace with your own implementation to customize.
+     * The default URL format is '{year}/{month}/{day}/{post name}'.
+     *
+     * @param resource the blog post resource 
+     *
+     * @return formatted url to the post page
+     */
+    def createPostUrl = { Map resource ->
+        def date = resource.date.format('yyyy/MM/dd/')
+        def title = resource.title.encodeAsSlug()
+        "$date$title/"
     }
 
     /**
@@ -72,7 +93,7 @@ class ResourceMapper {
                 update.url = getFingerprintUrl(resource)
                 break
             case ~/\/blog\/.*/:
-                update.url = getPostUrl('/blog/', resource)
+                update.url = getPostUrl(postUrlBasePath, resource)
                 break
         }
 
@@ -141,7 +162,7 @@ class ResourceMapper {
                         page + [url: feedUrl, tag: tag, posts: postsByCategory(tag).take(maxRss)]
                     }
                     break
-                case ~/\/blog\/.*/:
+                case { it.startsWith(postUrlBasePath) }:
                     def post = posts.find { it.url == page.url }
                     def index = posts.indexOf(post)
                     def prev = index > 0 ? posts[index - 1] : null
@@ -175,7 +196,8 @@ class ResourceMapper {
     }
 
     /**
-     * Creates URL for a post page. The URL format is '{base path}/{year}/{month}/{day}/{post name}'.
+     * Creates URL for a post page. Delegates to createPostUrl() to provide the URL format
+     * relative to the basePath.
      *
      * @param basePath base path to the page
      * @param location location of the file
@@ -183,9 +205,7 @@ class ResourceMapper {
      * @return formatted url to the post page
      */
     private String getPostUrl(String basePath, Map resource) {
-        def date = resource.date.format('yyyy/MM/dd/')
-        def title = resource.title.encodeAsSlug()
-        "$basePath$date$title/"
+        "$basePath${createPostUrl(resource)}"
     }
 
     /**


### PR DESCRIPTION
This change makes it possible to customize the blog post URLs while maintaining the existing functionality of `ResourceMapper`. For instance, it makes it possible to change the URLs to `"/articles/${resource.title.encodeAsSlug()}"`, (which is what I did), without breaking features such as the post pagination.

# Usage
By default, the `ResourceMapper` is configured to be backwards compatible, so the output remains the same. But two configuration properties are available: `String postUrlBasePath` and `Closure createPostUrl`. Here's an example configuration:

**SiteConfig.groovy**

    ...
    resource_mapper = new ResourceMapper(site).with {
        postUrlBasePath = '/articles/'
        createPostUrl = { Map resource -> "${resource.title.encodeAsSlug()}/" }
        delegate
    }.map
    ...

`postUrlBasePath` is used in place of the hard-coded path `/blog/`. It's real purpose however is to allow the `customizeModels` closure to detect post resources. The `createPostUrl` closure is called by `getPostUrl(String basePath, Map resource)`. The new closure does the bulk of the work previously done by `getPostUrl()`, which now merely prepends the `postUrlBasePath`.

# Duplicate URLs
I realize that changing the blog post URLs as I did has the potential to create duplicate URLs if I happen to have two posts with the same title. So I added `checkForDuplicateUrls` as the last *resource processor* in the chain. The closure throws an exception when it detects a duplicate URL, so there's no way for one to sneak by unnoticed.